### PR TITLE
Load mapping

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ def load_csv_to_db(csv_data, server, authkey, dry_run=True):
     entrynames = csv_data[0]
     failed_entries = []
     for row in csv_data[1:]:
-        # Print dry run results if no server address
+        # Do a dry run if no server address
         if not server:
             dry_run = True
             server = '0.0.0.0'

--- a/main.py
+++ b/main.py
@@ -2,12 +2,14 @@ import argparse
 import csv
 import requests
 
+
 def auth(username, password, server):
     print(username)
-    postdata = {'username':username, 'password':password}
+    postdata = {'username': username, 'password': password}
     res = requests.post(server, json=postdata)
     print(res.text)
     return res.json()
+
 
 def write_fail_csv(entries, path):
     with open(path, 'w') as csv_f:
@@ -34,8 +36,8 @@ def parse_csv(csv_path, server, authkey, dry_run=False):
                     failed_entries.append(row)
             else:
                 entrynames = row
-                #row.extend(['postdata', 'response code'])
-                #failed_entries.append(row)
+                # row.extend(['postdata', 'response code'])
+                # failed_entries.append(row)
                 i += 1
     return failed_entries
 
@@ -43,15 +45,14 @@ def parse_csv(csv_path, server, authkey, dry_run=False):
 def send_entry(server, entry, entrynames, dry_run, authkey):
     url = server
     postdata = {
-        #entrynames[0]: str(entry[0]),
+        # entrynames[0]: str(entry[0]),
         entrynames[1]: str(entry[1]),
         entrynames[2]: str(entry[2]),
         entrynames[3]: str(entry[3]),
         entrynames[4]: str(entry[4])
-        #TODO: Add a way to specify the columns we are sending. Sometimes the server will complain if we send an undefined column
+        # TODO: Add a way to specify the columns we are sending. Sometimes the server will complain if we send an undefined column
     }
     if not dry_run:
-        #auth_headers = "Authorization: JWT " + authkey['access_token']
         auth_headers = {'Authorization': 'JWT ' + authkey['access_token']}
         res = requests.post(url, json=postdata, headers=auth_headers)
         res_code = res.status_code

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import argparse
 import csv
+import json
+
 import requests
 
 
@@ -27,42 +29,69 @@ def parse_csv_to_memory(csv_path):
     return csv_data
 
 
-def load_csv_to_db(csv_data, server, authkey, dry_run=True):
-    """Unlike previous version this defaults to dry_run since it's
-    probably safer.
-    """
-    entrynames = csv_data[0]
+def load_csv_to_db(csv_data, entrymap, server, authkey, dry_run=False):
     failed_entries = []
-    for row in csv_data[1:]:
+    for entry in csv_data[1:]:
         # Do a dry run if no server address
         if not server:
             dry_run = True
             server = '0.0.0.0'
         res_code, postdata = send_entry(
-            server, row, entrynames, dry_run, authkey)
+            server, entry, entrymap, dry_run, authkey)
         if res_code != 200 and res_code != 201:  # STATUS CODE not OK
-            row.extend([postdata, res_code])
-            failed_entries.append(row)
+            entry.extend([postdata, res_code])
+            failed_entries.append(entry)
     return failed_entries
 
 
-def send_entry(server, entry, entrynames, dry_run, authkey):
-    url = server
-    postdata = {
-        # entrynames[0]: str(entry[0]),
-        entrynames[1]: str(entry[1]),
-        entrynames[2]: str(entry[2]),
-        entrynames[3]: str(entry[3]),
-        entrynames[4]: str(entry[4])
-        # TODO: Add a way to specify the columns we are sending. Sometimes the server will complain if we send an undefined column
-    }
+def build_entrymap(csv_column_names, column_map):
+    """Builds a db column name to csv column index mapping. If no mapping file
+    is given, we naively create the mapping using the order of the rows.
+
+    column_map provided should be {csv column name: db column name},
+    not including the primary ID.
+    """
+    # Naive approach, assumes the csv column names matches the db column names
+    db_content_names = csv_column_names[1:]
+    if column_map is None:
+        return {
+            column_name: index
+            for index, column_name in enumerate(db_content_names, start=1)
+        }
+
+    if len(column_map) != len(db_content_names):
+        print("WARNING: The db and csv column mapping file provided are "
+              "mismatched in length. db column names are: "
+              f"\n{db_content_names}\nThe provided column mapping "
+              f"generated the following maping: \n{column_map}")
+
+    # Using mapping provided by user to create the mapping
+    db_column_to_index_map = {}
+    for csv_column_name, db_column_name in column_map.items():
+        if csv_column_name not in db_content_names:
+            print(f"WARNING: {csv_column_name} not part of the db column "
+                  f"names for values {db_content_names}. This may be warning"
+                  "may be triggered due to including the primary key in the "
+                  "mapping file. To not have this warning printed, remove "
+                  "that mapping entry.")
+            continue
+        db_column_to_index_map[db_column_name] = csv_column_names.index(
+            csv_column_name)
+    return db_column_to_index_map
+
+
+def send_entry(server, entry, entrymap, dry_run, authkey):
+    postdata = {}
+    for column_name, csv_index in entrymap.items():
+        postdata[column_name] = entry[csv_index]
+
+    print(postdata)
     if not dry_run:
         auth_headers = {'Authorization': 'JWT ' + authkey['access_token']}
-        res = requests.post(url, json=postdata, headers=auth_headers)
+        res = requests.post(server, json=postdata, headers=auth_headers)
         res_code = res.status_code
         print(res_code, res)
     else:
-        print(postdata)
         res_code = 200  # STATUS CODE OK
     return res_code, postdata
 
@@ -78,8 +107,20 @@ def main(argv):
     authkey = auth(argv.auth_username, argv.auth_password, argv.auth_api)
 
     csv_data = parse_csv_to_memory(argv.csv_path)
+
+    if argv.entrymap_path is not None:
+        with open(argv.entrymap_path, "r") as fp:
+            column_map = json.load(fp)
+    entrymap = build_entrymap(
+        csv_column_names=csv_data[0],
+        column_map=column_map)
+
     failed_entries = load_csv_to_db(
-        csv_data, argv.server_address, authkey, argv.dry_run)
+        csv_data=csv_data,
+        entrymap=entrymap,
+        server=argv.server_address,
+        authkey=authkey,
+        dry_run=argv.dry_run)
 
     total_failed_entries = len(failed_entries)
     if total_failed_entries > 1:
@@ -97,6 +138,11 @@ if __name__ == "__main__":
     parser.add_argument(
         '--csv_path', '-c', dest='csv_path', required=True,
         help='the path to the csv file')
+    parser.add_argument(
+        '--entrymap_path', '-e', dest='entrymap_path', required=False,
+        default=None,
+        help='the path to the JSON mapping file for db column names to csv'
+        ' column names')
     parser.add_argument(
         '--dry_run', '-d', dest='dry_run', action='store_true',
         help='performs a dry run locally when provided with a '


### PR DESCRIPTION
Fixes #8 by adding the capability for someone to add a simple JSON mapping file, mapping the csv column name to db column name. Demonstration of the addition:

```python
In [1]: from main import build_entrymap

In [2]: import json

In [3]: with open("test.json", "r") as fp:
   ...:     data = json.load(fp)
   ...: 

In [4]: data
Out[4]: {'asdf': '1234', 'qwer': '2345', 'zxcv': '3456'}

In [5]: entry_map = build_entrymap(["datetime", "qwer", "asdf", "zxcv"], data)

In [6]: entry_map
Out[6]: {'1234': 2, '2345': 1, '3456': 3}
```

In the case where no mapping file is provided, we do the naive approach and assign index and db names based on the csv row provided, while omitting the first value. This is effectively what's hardcoded within the current code.
```python
In [7]: build_entrymap(["datetime", "qwer", "asdf", "zxcv"], None)
Out[7]: {'qwer': 1, 'asdf': 2, 'zxcv': 3}

```